### PR TITLE
Change go.sh to generic version

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -20,5 +20,36 @@
 #    files (e.g. signed public releases should match signed intel releases).
 #    "publish" rule. 
 
-echo "Nothing implemented"
+ROOT=
+INTEL_PATH=lib/firmware/intel
+VERSION=$(git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3| cut -d"-" -f 2)
 
+echo "Installing Intel firmware and topology $VERSION to $INTEL_PATH"
+
+# wipe previous releases
+rm -rf ${ROOT}/${INTEL_PATH}/sof/*
+rm -rf ${ROOT}/${INTEL_PATH}/sof-tplg-*
+rm -rf ${ROOT}/${INTEL_PATH}/sof-tplg
+
+# copy to destination
+cd lib/firmware
+cp -rf intel ${ROOT}/lib/firmware
+
+# add symlinks
+cd ${ROOT}/${INTEL_PATH}/sof
+
+ln -s ${VERSION}/sof-bdw-${VERSION}.ri sof-bdw.ri
+ln -s ${VERSION}/sof-byt-${VERSION}.ri sof-byt.ri
+ln -s ${VERSION}/sof-cht-${VERSION}.ri sof-cht.ri
+ln -s ${VERSION}/intel-signed/sof-apl-${VERSION}.ri sof-apl.ri
+ln -s ${VERSION}/intel-signed/sof-apl-${VERSION}.ri sof-glk.ri
+ln -s ${VERSION}/intel-signed/sof-cnl-${VERSION}.ri sof-cfl.ri
+ln -s ${VERSION}/intel-signed/sof-cnl-${VERSION}.ri sof-cnl.ri
+ln -s ${VERSION}/intel-signed/sof-cnl-${VERSION}.ri sof-cml.ri
+ln -s ${VERSION}/intel-signed/sof-icl-${VERSION}.ri sof-icl.ri
+
+
+cd ..
+ln -s sof-tplg-${VERSION} sof-tplg
+
+echo "Done installing Intel firmware and topology $VERSION"


### PR DESCRIPTION
Read git branch info for version number. No need to update
go.sh for each release.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>