### PR TITLE
implement go.sh

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,24 +1,50 @@
-# TODO: Helper script - automate the mundane !
+#!/bin/bash
 
-# This script should do several things.
+# This script installs the firmware and topologies in /lib/firmware/intel.
+# Optionally if ROOT is set as an environment variable by the caller it will be
+# prepended to the installation path.
 #
-# 1) Install the firmware and topologies in the correct target directories
-#    depending on PREFIX and vendor. PREFIX should be set as cmd line argument
-#    otherwise default to /lib/firmware. "install" rule.
-#
-# 2) As 1, but for the ldc files. This is the "install_debug" rule.
-#
-# 3) Take a SOF tag as cmd line argument, checkout tag locally, build topologies
-#    and copy them here under tag name directory. "update-tplg" rule.
-#
-# 4) As 3, but for firmware and sign with public key. Build with XCC where
-#    possible or download binaries (signed with any key) from external resource.
-#    "update-firmware" rule.
-#
-# 5) Publish all new topologies and firmwares by commiting and pushing this
-#    local copy of repo to upstream master. This should check for any missing
-#    files (e.g. signed public releases should match signed intel releases).
-#    "publish" rule. 
+# The script will attempt to use git to work out the version automatically, if
+# that is not possible on your environment specify SOF_VERSION as an environment
+# variable when calling.
 
-echo "Nothing implemented"
+test -n "${ROOT}" ||  \
+    ROOT=
+test -n "${INTEL_PATH}" || \
+    INTEL_PATH=lib/firmware/intel
+test -n "${SOF_VERSION}" || \
+    SOF_VERSION=$(git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3| cut -d"-" -f 2)
+test -n "${SOF_VERSION}" || \
+    { echo "Can't work out SOF_VERSION using git, please specify SOF_VERSION as environment variable"; exit 1; }
 
+test -d ${INTEL_PATH}/sof-tplg-${SOF_VERSION} || \
+    { echo "Can't find version ${SOF_VERSION} - are you missing leading v?"; exit 2; }
+
+echo "Installing Intel firmware and topology $SOF_VERSION to $INTEL_PATH"
+
+# wipe previous releases
+rm -rf ${ROOT}/${INTEL_PATH}/sof/*
+rm -rf ${ROOT}/${INTEL_PATH}/sof-tplg-*
+rm -rf ${ROOT}/${INTEL_PATH}/sof-tplg
+
+# copy to destination
+cd lib/firmware
+cp -rf intel ${ROOT}/lib/firmware
+
+# add symlinks
+cd ${ROOT}/${INTEL_PATH}/sof
+
+ln -s ${SOF_VERSION}/sof-bdw-${SOF_VERSION}.ri sof-bdw.ri
+ln -s ${SOF_VERSION}/sof-byt-${SOF_VERSION}.ri sof-byt.ri
+ln -s ${SOF_VERSION}/sof-cht-${SOF_VERSION}.ri sof-cht.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-apl-${SOF_VERSION}.ri sof-apl.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-apl-${SOF_VERSION}.ri sof-glk.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-cnl-${SOF_VERSION}.ri sof-cfl.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-cnl-${SOF_VERSION}.ri sof-cnl.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-cnl-${SOF_VERSION}.ri sof-cml.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-icl-${SOF_VERSION}.ri sof-icl.ri
+
+cd ..
+ln -s sof-tplg-${SOF_VERSION} sof-tplg
+
+echo "Done installing Intel firmware and topology $SOF_VERSION"


### PR DESCRIPTION
* Fixed the TODO comment which was inaccurate as packaging became publish.sh responsibility
* Went with a fallback approach on SOF_VERSION - try to use git and if not ask the user to specify it - since this repo is targetted at packagers, they should already know as they had to check out the correct branch

I had a look through the pull requests on this topic existing and want to pre-emptively address the following:

> Can you use longer variable names to minimize collision risks? Examples: FS_ROOT, INTEL_FW_PATH, SOF_VERSION,...
> Or even safer and simpler: make these local in the new, main() function.
> Could you move all the code into a main() function? It makes it easier to source the script for interactive testing by commenting out just the final line, lets add functions in any order and moves everything at the same indentation level (when this script grows functions).

Can definitely be improved but doesn't stop it form being merged now as it's better than releasing broken versions. As an external contributor (albeit one who agrees), this stylistic thing I will leave to the intel guys :) Changing ROOT is a bc break if you care, but I wouldn't as it would be trivial for packagers to find this out with proper release notes.

> This should be two for loops:
> 
> for product in bdw byt cht; do
>    ln -s ${VERSION}/sof-${product}-${VERSION}.ri sof-${product}.ri
> done

No, if you look closer, $product is not always the same on both sides of the ln command.

I have tested this to build an arch package and all is well but need it merged to make the 1.6 release on arch.  I would suggest maybe merge this so you at least have a working version and then raise an internal issue for tracking desirable improvements. 