### PR TITLE
update publish script to check FW binary

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -48,6 +48,7 @@ ln -s ${SOF_VERSION}/intel-signed/sof-icl-${SOF_VERSION}.ri sof-icl.ri
 ln -s ${SOF_VERSION}/intel-signed/sof-jsl-${SOF_VERSION}.ri sof-jsl.ri
 ln -s ${SOF_VERSION}/intel-signed/sof-tgl-${SOF_VERSION}.ri sof-tgl.ri
 ln -s ${SOF_VERSION}/intel-signed/sof-ehl-${SOF_VERSION}.ri sof-ehl.ri
+ln -s ${SOF_VERSION}/intel-signed/sof-tgl-h-${SOF_VERSION}.ri sof-tgl-h.ri
 # link community-signed binary
 mkdir -p ${ROOT}/${INTEL_PATH}/sof/community/
 cd ${ROOT}/${INTEL_PATH}/sof/community/
@@ -60,6 +61,7 @@ ln -s ../${SOF_VERSION}/public-signed/sof-icl-${SOF_VERSION}.ri sof-icl.ri
 ln -s ../${SOF_VERSION}/public-signed/sof-jsl-${SOF_VERSION}.ri sof-jsl.ri
 ln -s ../${SOF_VERSION}/public-signed/sof-tgl-${SOF_VERSION}.ri sof-tgl.ri
 ln -s ../${SOF_VERSION}/public-signed/sof-tgl-${SOF_VERSION}.ri sof-ehl.ri
+ln -s ../${SOF_VERSION}/public-signed/sof-tgl-h-${SOF_VERSION}.ri sof-tgl-h.ri
 
 cd ${ROOT}/${INTEL_PATH}/
 ln -s sof-tplg-${SOF_VERSION} sof-tplg

--- a/publish.sh
+++ b/publish.sh
@@ -9,8 +9,8 @@ SOF_RI_INFO_URL="https://raw.githubusercontent.com/thesofproject/sof/master/tool
 
 # Need to check and update the release platforms
 NO_SIGNED_PLATFORMS=(byt cht bdw)
-PUBLIC_SIGNED_PLATFORMS=(apl cnl icl jsl tgl)
-INTEL_SIGNED_PLATFORMS=(apl cnl icl tgl ehl)
+PUBLIC_SIGNED_PLATFORMS=(apl cnl icl jsl tgl tgl-h)
+INTEL_SIGNED_PLATFORMS=(apl cnl icl tgl tgl-h ehl)
 
 ISSUED_PLATFORMS=""
 
@@ -103,7 +103,14 @@ done
 
 for platform in "${INTEL_SIGNED_PLATFORMS[@]}"
 do
-  [[ "$INTEL_SIGNED_SRC_DIR" ]] && check_fw "$platform Intel prod" "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri"
+  case $platform in
+    tgl-h)
+      [[ "$INTEL_SIGNED_SRC_DIR" ]] && check_fw "TGL Intel prod" "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri"
+      ;;
+    *)
+      [[ "$INTEL_SIGNED_SRC_DIR" ]] && check_fw "$platform Intel prod" "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri"
+      ;;
+  esac
 done
 
 if [[ -n "$ISSUED_PLATFORMS" ]]; then

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,10 @@
 # stop on most errors
 set -e
 
-RELEASE_PLATFORMS=(byt cht bdw apl cnl icl jsl tgl ehl)
+# Need to check and update the release platforms
+NO_SIGNED_PLATFORMS=(byt cht bdw)
+PUBLIC_SIGNED_PLATFORMS=(apl cnl icl jsl tgl)
+INTEL_SIGNED_PLATFORMS=(apl cnl icl tgl ehl)
 
 BIN_DIR=$(pwd)
 
@@ -62,23 +65,21 @@ mkdir -p "$TOOLS_DIR"
 mkdir -p "$TPLG_DIR"
 
 # publish FW
-for platform in "${RELEASE_PLATFORMS[@]}"
+for platform in "${NO_SIGNED_PLATFORMS[@]}"
 do
-  case $platform in
-    # lagcy platform, no sign needed
-    byt | cht | bdw)
-      [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ri" "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
-      ;;
-    apl | cnl | icl | tgl | jsl)
-      [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
-      [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ri" "$BIN_DIR/$PUBLIC_SIGNED_DIR"
-      [[ "$INTEL_SIGNED_SRC_DIR" ]] && cp "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri" "$BIN_DIR/$INTEL_SIGNED_DIR"
-      ;;
-    # ehl is same binary with tgl but different intel key to sign
-    ehl)
-      [[ "$INTEL_SIGNED_SRC_DIR" ]] && cp "$INTEL_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
-      [[ "$INTEL_SIGNED_SRC_DIR" ]] && cp "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri" "$BIN_DIR/$INTEL_SIGNED_DIR"
-  esac
+  [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ri" "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
+done
+
+for platform in "${PUBLIC_SIGNED_PLATFORMS[@]}"
+do
+  [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
+  [[ "$PUBLIC_SIGNED_SRC_DIR" ]] && cp "$PUBLIC_SIGNED_SRC_DIR/sof-$platform.ri" "$BIN_DIR/$PUBLIC_SIGNED_DIR"
+done
+
+for platform in "${INTEL_SIGNED_PLATFORMS[@]}"
+do
+  [[ "$INTEL_SIGNED_SRC_DIR" ]] && cp "$INTEL_SIGNED_SRC_DIR/sof-$platform.ldc" "$BIN_DIR/$SOF_FW_DIR"
+  [[ "$INTEL_SIGNED_SRC_DIR" ]] && cp "$INTEL_SIGNED_SRC_DIR/sof-$platform.ri" "$BIN_DIR/$INTEL_SIGNED_DIR"
 done
 
 # rename the ri and ldc files


### PR DESCRIPTION
check FW binary key with [sof_ri_info.py](https://github.com/thesofproject/sof/blob/master/tools/sof_ri_info/sof_ri_info.py) tool
TODO:
- [ ] check FW binary TAG 
- [ ] check LDC files binary TAG

Example to use:

```
./publish.sh -c -i ~/work/sof/release/1.6.1/production/
========================================================================
checking /home/pxl/work/sof/release/1.6.1/production/sof-apl.ri
1f f4 58 74 64 d4 ae 90 ... b5 c2 49 4e 2a 5f 47 c2 (APL Intel prod key)
sof-apl.ri get correct key
========================================================================
checking /home/pxl/work/sof/release/1.6.1/production/sof-cnl.ri
41 a0 3e 14 1e 7e 29 72 ... cd 1d fa fd e8 a0 ba 91 (CNL Intel prod key)
sof-cnl.ri get correct key
========================================================================
checking /home/pxl/work/sof/release/1.6.1/production/sof-icl.ri
63 df 54 e3 c1 e5 d9 d2 ... 35 f1 ec 4d 93 73 e6 c4 (ICL Intel prod key)
sof-icl.ri get correct key
========================================================================
checking /home/pxl/work/sof/release/1.6.1/production/sof-tgl.ri
d3 72 92 99 4e b9 cd 67 ... 5d 62 4a 80 96 31 f8 b5 (TGL Intel prod key)
sof-tgl.ri get correct key
========================================================================
checking /home/pxl/work/sof/release/1.6.1/production/sof-ehl.ri
b5 b0 e2 25 3d c7 54 10 ... ad 23 46 0c 9f fc 3e b9 (EHL Intel prod key)
sof-ehl.ri get correct key
========================================================================
All FW binary pass check!
```