### PR TITLE
Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ the go.sh script is not used anymore. Instead:
 ```
 sudo mv /lib/firmware/intel/sof* some_backup_location/
 sudo mv /usr/local/bin/sof-*     some_backup_location/ # optional
-sudo install.sh v1.N.x/v1.N-rcM
+sudo ./install.sh v1.N.x/v1.N-rcM
 ```
 
 The go.sh script still applies to older releases.


### PR DESCRIPTION
Depending on your $PATH, if the local directory is not in the path, `install.sh` will not to be resolvable:
```
$ sudo install.sh v1.8.x/v1.8-rc2 
sudo: install.sh: command not found
```
so `./install.sh` needs to be used.