### PR TITLE
sof-v1.9: add ADL symbolic links

### DIFF
--- a/v1.9.x/sof-v1.9/community/sof-adl-s.ri
+++ b/v1.9.x/sof-v1.9/community/sof-adl-s.ri
@@ -1,0 +1,1 @@
+sof-tgl-h.ri

--- a/v1.9.x/sof-v1.9/community/sof-adl.ri
+++ b/v1.9.x/sof-v1.9/community/sof-adl.ri
@@ -1,0 +1,1 @@
+sof-tgl.ri

--- a/v1.9.x/sof-v1.9/sof-adl-s.ri
+++ b/v1.9.x/sof-v1.9/sof-adl-s.ri
@@ -1,0 +1,1 @@
+intel-signed/sof-adl-s.ri


### PR DESCRIPTION
Manually created for now, will be automatically generated once
sof commit 5a7a135f018 is backported (https://github.com/thesofproject/sof/pull/4804)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>