### PR TITLE
Fix path in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ main()
 
     local path; path=$(dirname "$1")
     local ver; ver=$(basename "$1")
-
+    local vpath; vpath="$(ls -d "${path}/${ver}"*)"
     # Do this first so we can fail immediately and not leave a
     # half-install behind
     set -x
@@ -37,10 +37,9 @@ main()
             die '%s already installed? (Re)move it first.\n' "${FW_DEST}/$sdir"
         }
     done
-
     # Trailing slash in srcdir/ ~= srcdir/*
-    rsync -a "${path}"/sof*"$ver" "${FW_DEST}"/
-    rsync -a "${path}"/tools-"$ver"/ "${TOOLS_DEST}"/
+    rsync -a "${vpath}/sof" "${FW_DEST}"/
+    rsync -a "${vpath}/tools-"*/ "${TOOLS_DEST}"/
 }
 
 die()

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ main()
     local path; path=$(dirname "$1")
     local ver; ver=$(basename "$1")
     local vpath; vpath="$(ls -d "${path}/${ver}"*)"
+    local tpath; tpath="$(ls -d "${vpath}/tools-"* | sort -V -r | head -1)"
     # Do this first so we can fail immediately and not leave a
     # half-install behind
     set -x
@@ -39,7 +40,7 @@ main()
     done
     # Trailing slash in srcdir/ ~= srcdir/*
     rsync -a "${vpath}/sof" "${FW_DEST}"/
-    rsync -a "${vpath}/tools-"*/ "${TOOLS_DEST}"/
+    rsync -a "${tpath}/" "${TOOLS_DEST}"/
 }
 
 die()


### PR DESCRIPTION
This PR fixes the install script by:

* Getting the path-to-version together first
* Replacing the forced version number from `tools-...` with a wildcard (the `tools` dir is `tools-v2.1.1`; if the user enters `v2.1.x` like in the `usage` statement, rsync gives up).