### PR TITLE
Add shellcheck Github Action, minor mac fixes

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,0 +1,19 @@
+---
+
+name: codestyle
+
+# yamllint disable-line rule:truthy
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: run tests
+        # Ignore SC3043 because every decent shell has 'local'. Let's not
+        # force every script to require bash when not required.
+        # (on Debian/Ubuntu bash is not the default)
+        run: shellcheck -e SC3043 *sh */*sh tests/*.bats

--- a/tarball_one_version.sh
+++ b/tarball_one_version.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ "$(uname)" = 'Darwin' ]; then
+    find() { # for -xtype
+        gfind "$@"  # brew install findutils
+    }
+fi
+
 usage()
 {
     cat <<EOF

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -1,7 +1,8 @@
 
 # https://bats-core.readthedocs.io/en/stable/tutorial.html
 
-
+# Warning: BATS seems able to neither trace nor show errors in setup*()
+# functions. Try --no-tempdir-cleanup and inspect logs there.
 setup_file()
 {
     load 'common_helpers.bash'; set_constants
@@ -11,7 +12,7 @@ setup_file()
 setup()
 {
     mkdir -p testruns/
-    RUN_DIR=$(mktemp --directory testruns/run-XXXXXX)
+    RUN_DIR=$(mktemp -d testruns/run-XXXXXX)
 }
 
 teardown()


### PR DESCRIPTION
Note there is NO commitment to support macOS, it is just a convenience available right now - until we really need something Linux-specific.