### PR TITLE
tests: show name of temporary "testruns" directory when diff fails

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -61,7 +61,7 @@ test_tarball_one_version()
 
     "$TOP_DIR"/tarball_one_version.sh "$dir"/"$ver" "$optional_git_tag"
     tar xf sof-bin-"$ver".tar.gz
-    diff -qr "$EXTR_REFS"/sof-bin-"$ver"  sof-bin-"$ver"/
+    diff -qr "$EXTR_REFS"/sof-bin-"$ver"  "$(pwd)/sof-bin-$ver"/
     popd || exit 1
 }
 
@@ -76,6 +76,6 @@ test_tarball_topologies_only()
 
     "$TOP_DIR"/tarball_topologies_only.sh "$dir"/"$ver"
     tar xf sof-tplg-"$ver".tar.gz
-    diff -qr "$EXTR_REFS"/sof-tplg-"$ver" sof-tplg-"$ver"/
+    diff -qr "$EXTR_REFS"/sof-tplg-"$ver" "$(pwd)"/sof-tplg-"$ver"/
     popd || exit 1
 }


### PR DESCRIPTION
"Only in sof-bin-v2.3/sof-v2.3: sof-tgl.ri" was not very useful, changed to:
"Only in /home/user.testruns/run-62m5fY/sof-bin-v2.3/sof-v2.3: sof-tgl.ri"

Signed-off-by: Marc Herbert <marc.herbert@intel.com>