### PR TITLE
tarball_multi_releases.sh: downgrade symlink pre-check to WARNING

### DIFF
--- a/tarball_multi_releases.bash
+++ b/tarball_multi_releases.bash
@@ -93,7 +93,7 @@ main()
     rmdir _selected_versions
 
     check_symlinks "$archive_name" ||
-        die "Found some broken symbolic links before combining\n"
+        >&2 printf "WARNING: Found some broken symbolic links before combining\n"
 
     # Now "install" versions in the given order and on top of each
     # other: last one wins. Record the version of each file for the


### PR DESCRIPTION
It should be fatal to release broken symlinks but resolving symlinks thanks to a combination of releases should be OK. So just WARN.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>