### PR TITLE
compare_signed.bats: define BATS_RUN_COMMAND when not available

### DIFF
--- a/tests/common_helpers.bash
+++ b/tests/common_helpers.bash
@@ -5,7 +5,7 @@ set_constants()
     # shellcheck disable=SC2034
     TOP_DIR=$(cd "${TESTS_DIR}"/.. && pwd)
     REFS="$TESTS_DIR"/refs/
-    EXTR_REFS="$TESTS_DIR"/extracted_refs/
+    EXTR_REFS="$TESTS_DIR"/refs_extracted
     # shellcheck disable=SC2034
     STATIC_REFS="$TESTS_DIR"/static_refs/
 

--- a/tests/compare_signed.bats
+++ b/tests/compare_signed.bats
@@ -91,6 +91,7 @@ test_init()
             *)
                 assert_eq_signed $status 0;;
         esac
+        printf '\n\n'
     done
 
     popd || return 1
@@ -121,7 +122,7 @@ assert_eq_signed()
     local actual=$1 expected=$2
 
     test "$actual" -eq "$expected" || {
-        >&2 printf 'Expected %d, got %d from %s\n\n\n' \
+        >&2 printf 'FAIL: expected %d, got %d from %s\n' \
             "$expected" "$actual" "$BATS_RUN_COMMAND"
             false
     }

--- a/tests/compare_signed.bats
+++ b/tests/compare_signed.bats
@@ -100,8 +100,13 @@ test_init()
 run_compare_signed()
 {
     local sofv="$1"
+    local run_cmd=("$TOP_DIR"/compare_signed_unsigned.py "$sofv")
 
-    run "$TOP_DIR"/compare_signed_unsigned.py "$sofv"
+    unset BATS_RUN_COMMAND
+    run "${run_cmd[@]}"
+    # BATS_RUN_COMMAND is not available in bats version 1.2.1
+    test -n "$BATS_RUN_COMMAND" || BATS_RUN_COMMAND="${run_cmd[*]}"
+
     # This is not modifying $output, shellcheck seems wrong
     # shellcheck disable=SC2031
     printf '%s\n' "$output"


### PR DESCRIPTION
3 commits. Main one: compare_signed.bats: define BATS_RUN_COMMAND when not available.

This makes failure logs MUCH more readable!