### PR TITLE
Remove broken intel-signed ADL and RPL symlinks from v2.4.1 

### DIFF
--- a/tests/compare_signed.bats
+++ b/tests/compare_signed.bats
@@ -90,6 +90,10 @@ test_init()
             *v2.3.x/sof-v2.3)
                 assert_eq_signed $status 6;;
 
+            # work still in progress, see commit message 124ac3bd6ff1
+            *v2.4.x/sof-v2.4.1)
+                assert_eq_signed $status 2;;
+
             # No difference or error expected
             *)
                 assert_eq_signed $status 0;;

--- a/v2.4.x/sof-v2.4.1/intel-signed/sofz-rpl-s.ri
+++ b/v2.4.x/sof-v2.4.1/intel-signed/sofz-rpl-s.ri
@@ -1,1 +1,0 @@
-sofz-adl-s.ri

--- a/v2.4.x/sof-v2.4.1/intel-signed/sofz-rpl.ri
+++ b/v2.4.x/sof-v2.4.1/intel-signed/sofz-rpl.ri
@@ -1,1 +1,0 @@
-sofz-adl.ri

--- a/v2.4.x/sof-v2.4.1/sofz-adl-s.ri
+++ b/v2.4.x/sof-v2.4.1/sofz-adl-s.ri
@@ -1,1 +1,0 @@
-intel-signed/sofz-adl-s.ri

--- a/v2.4.x/sof-v2.4.1/sofz-adl.ri
+++ b/v2.4.x/sof-v2.4.1/sofz-adl.ri
@@ -1,1 +1,0 @@
-intel-signed/sofz-adl.ri

--- a/v2.4.x/sof-v2.4.1/sofz-rpl-s.ri
+++ b/v2.4.x/sof-v2.4.1/sofz-rpl-s.ri
@@ -1,1 +1,0 @@
-intel-signed/sofz-rpl-s.ri

--- a/v2.4.x/sof-v2.4.1/sofz-rpl.ri
+++ b/v2.4.x/sof-v2.4.1/sofz-rpl.ri
@@ -1,1 +1,0 @@
-intel-signed/sofz-rpl.ri


### PR DESCRIPTION
Only TGL is intel-signed in v2.4.1