### PR TITLE
docs: Update README.md for folder creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ the convenience ``./install.sh`` script:
 ```
 tar zxf sof-bin-2023.09.tar.gz
 cd sof-bin-2023.09
+mkdir some_backup_location
 sudo mv /lib/firmware/intel/sof* some_backup_location/
-sudo mv /usr/local/bin/sof-*     some_backup_location/ # optional
+sudo mv /usr/local/bin/sof-*     .some_backup_location/ # optional
 sudo ./install.sh
 ```
 
@@ -42,6 +43,7 @@ sudo ./install.sh
 To run install from sof-bin git checkout:
 
 ```
+mkdir some_backup_location
 sudo mv /lib/firmware/intel/sof* some_backup_location/
 sudo mv /usr/local/bin/sof-*     some_backup_location/ # optional
 sudo ./install.sh v1.N.x/v1.N-rcM


### PR DESCRIPTION
A reference to the 'some_backup_location' directory was made before it was created, which could potentially lead to issues. This commit ensures a smoother user experience by adding the command 'mkdir some_backup_location' to create the directory before moving any files into it. This prevents any potential errors and ensures that the provided instructions work as expected.