### PR TITLE
v2.10.x: remove extra sof-rpl.ri

### DIFF
--- a/v2.10.x/sof-ipc4-v2.10/tgl/community/sof-rpl.ri
+++ b/v2.10.x/sof-ipc4-v2.10/tgl/community/sof-rpl.ri
@@ -1,1 +1,0 @@
-../../tgl/community/sof-tgl.ri


### PR DESCRIPTION
Remove unneeded tgl/community/sof-rpl.ri file from the v2.10 release.