### PR TITLE
[DNM] Add missing links for SOF v2.11.1 signed Intel binaries for ARL

### DIFF
--- a/v2.11.x/sof-ipc4-v2.11.1/arl/intel-signed/sof-arl.ri
+++ b/v2.11.x/sof-ipc4-v2.11.1/arl/intel-signed/sof-arl.ri
@@ -1,0 +1,1 @@
+../../mtl/sof-mtl.ri

--- a/v2.11.x/sof-ipc4-v2.11.1/arl/sof-arl.ri
+++ b/v2.11.x/sof-ipc4-v2.11.1/arl/sof-arl.ri
@@ -1,0 +1,1 @@
+intel-signed/sof-arl.ri


### PR DESCRIPTION
Intel Arrow Lake shares the same audio DSP and can use the same firmware binaries as MTL, but as kernel driver looks up the firmware with a unique name, add the missing symbolic links for signed binaries.