### PR TITLE
v2.11.x: fixup the intel-signed/sof-arl.ri link

### DIFF
--- a/v2.11.x/sof-ipc4-v2.11.1/arl/intel-signed/sof-arl.ri
+++ b/v2.11.x/sof-ipc4-v2.11.1/arl/intel-signed/sof-arl.ri
@@ -1,1 +1,1 @@
-../../mtl/sof-mtl.ri
+../../mtl/intel-signed/sof-mtl.ri


### PR DESCRIPTION
Modify the symbolic link to explicitly link intel-signed/sof-arl.ri to the intel-signed/sof-mtl.ri binary.

This is first such symbolic link for a intel-signed image, so better to set a clean first example as this approach is likely to be copied to handle other similar cases.