### PR TITLE
README.md: clarify platform applicability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## Notice on Platform Coverage
 
+While sof-bin repository is open to all vendors, in practise only
+binaries for Intel based systems have been distributed using this
+method so far. For pragmatic reasons, examples in this documentation
+use Intel binaries as examples as those are currently available.
+
 WARNING: starting with v2.2, older Intel products are not supported by
 the main SOF development branch anymore. To avoid duplication and
 confusion in this sof-bin git repository, older product generations are
@@ -36,6 +41,9 @@ sudo mv /lib/firmware/intel/sof* some_backup_location/
 sudo mv /usr/local/bin/sof-*     some_backup_location/ # optional
 sudo ./install.sh
 ```
+
+The install script is intended for Linux systems where the Linux kernel
+will look up firmware binaries under /lib/firmware.
 
 ## Install process with install.sh (sof-bin git tree)
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -202,6 +202,10 @@ test_install_one_version()
     # anymore
     git show v2023.12.1:install.sh > "$(pwd)/sof-bin-$ver"/install.sh
 
+    # install.sh was updated in 2025.01, so it won't match
+    # anymore
+    git show v2023.12.1:README.md > "$(pwd)/sof-bin-$ver"/README.md
+
     diff -qr "$EXTR_REFS"/sof-bin-"$ver"  "$(pwd)/sof-bin-$ver"/
 
     popd || exit 1


### PR DESCRIPTION
Clarify the README.md text to emphasize that this repository and upstream release process is open to all vendors. Some of the examples are Intel specific and/or use e.g. Intel specific firmware paths as examples, as that is what is currently distributed.